### PR TITLE
limit logging of proxied requests that are OK (2XX)

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -279,13 +279,16 @@ impl ProxyHttp for Umami {
 	where
 		Self::CTX: Send + Sync,
 	{
-		info!(
-			"status: {}, reason {:?}, {} - Origin: {}",
-			upstream_response.status,
-			upstream_response.get_reason_phrase(),
-			session.request_summary(),
-			ctx.ingress
-		);
+		let status = upstream_response.status;
+		if !status.is_success() {
+			info!(
+				"status: {}, reason {:?}, {} - Origin: {}",
+				status,
+				upstream_response.get_reason_phrase(),
+				session.request_summary(),
+				ctx.ingress
+			);
+		}
 		Ok(())
 	}
 


### PR DESCRIPTION
since the log output becomes fairly spammy with large amounts of usage, the OK messages that log rows are inserted successfully (proxied) is less useful to us? (can be enabled again later, but for now, the output of `kubectl logs` for the pods gets a bit swamped).

another thing I'm uncertain about... are these log events stored forever somewhere? 🤔 